### PR TITLE
feat: Sparkle auto-updates with beta channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,10 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.release.outputs.target_ref }}
 
+      - name: Verify changelog section exists
+        shell: bash
+        run: ./script/extract_changelog.sh --version "${{ steps.release.outputs.release_tag }}" >/dev/null
+
       - name: Run Swift tests
         shell: bash
         run: swift test
@@ -94,6 +98,11 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_NOTARY_APPLE_ID }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_NOTARY_TEAM_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_NOTARY_APP_PASSWORD }}
+      BEADAZZLE_SPARKLE_PUBLIC_KEY: ${{ vars.SPARKLE_ED_PUBLIC_KEY }}
+      SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
+      # Keep in sync with the Sparkle version pinned in Package.swift so the
+      # generate_appcast tool matches the embedded framework.
+      SPARKLE_TOOLS_VERSION: "2.9.4"
     steps:
       - name: Validate release secrets
         shell: bash
@@ -106,7 +115,9 @@ jobs:
             APPLE_DEVELOPER_ID_P12_PASSWORD \
             APPLE_ID \
             APPLE_TEAM_ID \
-            APPLE_APP_SPECIFIC_PASSWORD; do
+            APPLE_APP_SPECIFIC_PASSWORD \
+            BEADAZZLE_SPARKLE_PUBLIC_KEY \
+            SPARKLE_ED_PRIVATE_KEY; do
             if [[ -z "${!variable_name:-}" ]]; then
               echo "::error::Missing required secret or environment value: $variable_name" >&2
               exit 1
@@ -189,6 +200,30 @@ jobs:
             --dmg-path "${{ steps.create_dmg.outputs.dmg_path }}" \
             --checksum-path "${{ steps.create_dmg.outputs.checksum_path }}"
 
+      - name: Prepare release notes from changelog
+        id: notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          notes_md="$RUNNER_TEMP/release-notes.md"
+          notes_html="$RUNNER_TEMP/release-notes.html"
+
+          # Fails the release if the tag has no matching CHANGELOG.md section.
+          ./script/extract_changelog.sh --version "$RELEASE_TAG" > "$notes_md"
+
+          # Render to HTML (GitHub-flavored) for the Sparkle update dialog.
+          gh api --method POST /markdown \
+            -f mode=gfm \
+            -f context="${GITHUB_REPOSITORY}" \
+            -f "text=$(cat "$notes_md")" > "$notes_html"
+
+          echo "notes_md=$notes_md" >> "$GITHUB_OUTPUT"
+          echo "notes_html=$notes_html" >> "$GITHUB_OUTPUT"
+
       - name: Publish GitHub release assets
         env:
           GH_TOKEN: ${{ github.token }}
@@ -196,6 +231,7 @@ jobs:
           TARGET_REF: ${{ needs.validate.outputs.target_ref }}
           DMG_PATH: ${{ steps.create_dmg.outputs.dmg_path }}
           CHECKSUM_PATH: ${{ steps.create_dmg.outputs.checksum_path }}
+          NOTES_MD: ${{ steps.notes.outputs.notes_md }}
         shell: bash
         run: |
           set -euo pipefail
@@ -203,7 +239,7 @@ jobs:
           if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
             gh release upload "$RELEASE_TAG" "$DMG_PATH" "$CHECKSUM_PATH" --clobber
           else
-            release_args=(release create "$RELEASE_TAG" "$DMG_PATH" "$CHECKSUM_PATH" --title "$RELEASE_TAG" --notes "Beta release $RELEASE_TAG")
+            release_args=(release create "$RELEASE_TAG" "$DMG_PATH" "$CHECKSUM_PATH" --title "$RELEASE_TAG" --notes-file "$NOTES_MD")
 
             # A semver pre-release identifier (e.g. -beta.1, -rc.1) always contains a hyphen.
             if [[ "$RELEASE_TAG" == *-* ]]; then
@@ -219,7 +255,66 @@ jobs:
             gh "${release_args[@]}"
           fi
 
+      - name: Install Sparkle appcast tools
+        id: sparkle_tools
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tools_dir="$RUNNER_TEMP/sparkle-tools"
+          mkdir -p "$tools_dir"
+          archive="$RUNNER_TEMP/sparkle-tools.tar.xz"
+
+          curl -fsSL \
+            "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_TOOLS_VERSION}/Sparkle-${SPARKLE_TOOLS_VERSION}.tar.xz" \
+            -o "$archive"
+          tar -xf "$archive" -C "$tools_dir" bin/generate_appcast
+
+          generate_appcast="$tools_dir/bin/generate_appcast"
+          chmod +x "$generate_appcast"
+          echo "generate_appcast=$generate_appcast" >> "$GITHUB_OUTPUT"
+
+      - name: Build appcast
+        id: appcast
+        env:
+          RELEASE_TAG: ${{ needs.validate.outputs.release_tag }}
+          DMG_PATH: ${{ steps.create_dmg.outputs.dmg_path }}
+          NOTES_HTML: ${{ steps.notes.outputs.notes_html }}
+          GENERATE_APPCAST: ${{ steps.sparkle_tools.outputs.generate_appcast }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          site_dir="$GITHUB_WORKSPACE/appcast-site"
+          ./script/build_appcast.sh \
+            --dmg-path "$DMG_PATH" \
+            --release-tag "$RELEASE_TAG" \
+            --notes-html "$NOTES_HTML" \
+            --generate-appcast "$GENERATE_APPCAST" \
+            --output-dir "$site_dir"
+
+          echo "site_dir=$site_dir" >> "$GITHUB_OUTPUT"
+
+      - name: Upload appcast as Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ steps.appcast.outputs.site_dir }}
+
       - name: Remove temporary signing keychain
         if: always() && steps.keychain.outputs.keychain_path != ''
         shell: bash
         run: security delete-keychain "${{ steps.keychain.outputs.keychain_path }}"
+
+  deploy_appcast:
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy appcast to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@ Beadazzle is a SwiftPM native macOS app. Prefer small, focused SwiftUI files and
 - For warnings tied to specific files, use `XcodeRefreshCodeIssuesInFile` on the affected source files after edits.
 - Do not stop at a successful shell build when Xcode reported warnings; verify through Xcode MCP that there are no current warnings or explain any stale runtime entries that remain in the navigator.
 
+## Changelog
+
+- Record user-facing changes in `CHANGELOG.md` under `## [Unreleased]` as part of the work that makes them — new features, behavior changes, notable fixes. Skip internal-only churn (refactors, test-only edits, CI plumbing) that a user would never notice.
+- Write entries for users of the app, not as commit summaries. The release workflow reads the tag's section for both the GitHub release notes and the in-app Sparkle update dialog, and a release fails if its section is missing. See `docs/AUTO_UPDATES.md`.
+
 ## Project Boundaries
 
 - Do not edit generated output in `.build/`, `.swiftpm/`, or `dist/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable changes to Beadazzle are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Entries under **Unreleased** ship in the next tagged build. When cutting a
+release, rename the heading to the version and date, then start a fresh
+**Unreleased** section. The release workflow reads the section matching the tag
+for both the GitHub release notes and the in-app update dialog, so write these
+for users, not for the commit log.
+
+## [Unreleased]
+
+### Added
+
+- Automatic updates via Sparkle: the app checks for new builds in the
+  background and presents a changelog with Install or Skip. A "Check for
+  Updates…" menu item is available under the app menu.
+- **Updates** settings pane with toggles for automatic update checks and for
+  receiving beta (pre-release) builds.
+
+## [0.1.0-beta.1]
+
+### Added
+
+- Initial public beta: native SwiftUI desktop client for Beads issue trackers,
+  with a source-list sidebar, filterable/sortable issue list, and detail view.
+- Reads from a populated `.beads/beads.db` with a JSONL fallback for embedded
+  projects; all mutations route through the `bd` CLI.
+- Signed and notarized DMG distribution.
+
+[Unreleased]: https://github.com/Mosnar/beadazzle/compare/v0.1.0-beta.1...HEAD
+[0.1.0-beta.1]: https://github.com/Mosnar/beadazzle/releases/tag/v0.1.0-beta.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ The read and write paths are deliberately separate:
 - SwiftUI first; use AppKit interop only for narrow platform edges (panels, window behavior). Keep files small and focused.
 - Preserve native macOS source-list behavior in the sidebar. Keep filters in the sidebar and list-specific controls (e.g. sorting) near the issue list. Favor compact, stable metadata over wrapped badges or card-heavy layouts.
 - Keep navigation/search responsive — avoid disk reads on simple selection; that's what the in-memory index is for.
+- Record user-facing changes in `CHANGELOG.md` under `## [Unreleased]` as you make them (features, behavior changes, notable fixes) — written for users, not as commit summaries. Skip internal-only churn a user wouldn't notice. The release workflow reads the tag's section for the GitHub release notes and the in-app Sparkle update dialog, and fails if it's missing; see `docs/AUTO_UPDATES.md`.
 
 ## Xcode warnings
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -10,6 +10,15 @@
       }
     },
     {
+      "identity" : "sparkle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/sparkle-project/Sparkle",
+      "state" : {
+        "revision" : "b6496a74a087257ef5e6da1c5b29a447a60f5bd7",
+        "version" : "2.9.4"
+      }
+    },
+    {
       "identity" : "swift-markdown-engine",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nodes-app/swift-markdown-engine",

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,8 @@ let package = Package(
         .executable(name: "Beadazzle", targets: ["Beadazzle"])
     ],
     dependencies: [
-        .package(url: "https://github.com/nodes-app/swift-markdown-engine", exact: "0.8.0")
+        .package(url: "https://github.com/nodes-app/swift-markdown-engine", exact: "0.8.0"),
+        .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.4")
     ],
     targets: [
         .systemLibrary(
@@ -21,7 +22,8 @@ let package = Package(
             name: "Beadazzle",
             dependencies: [
                 "CSQLite",
-                .product(name: "MarkdownEngine", package: "swift-markdown-engine")
+                .product(name: "MarkdownEngine", package: "swift-markdown-engine"),
+                .product(name: "Sparkle", package: "Sparkle")
             ],
             path: "Sources/Beadazzle"
         ),

--- a/Sources/Beadazzle/App/BeadazzleApp.swift
+++ b/Sources/Beadazzle/App/BeadazzleApp.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct BeadazzleApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @State private var store = BeadStore()
+    private let updaterController = UpdaterController()
 
     var body: some Scene {
         WindowGroup("Beadazzle", id: "main") {
@@ -14,6 +15,10 @@ struct BeadazzleApp: App {
         }
         .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
+            CommandGroup(after: .appInfo) {
+                CheckForUpdatesView(updater: updaterController.updater)
+            }
+
             CommandGroup(replacing: .newItem) {
                 Button("New Bead") {
                     NotificationCenter.default.post(name: .newBeadRequested, object: nil)
@@ -72,6 +77,7 @@ struct BeadazzleApp: App {
         Settings {
             SettingsView()
                 .environment(store)
+                .environmentObject(updaterController)
         }
         .windowToolbarStyle(.unifiedCompact)
         .windowResizability(.contentMinSize)

--- a/Sources/Beadazzle/Models/BeadazzlePreferences.swift
+++ b/Sources/Beadazzle/Models/BeadazzlePreferences.swift
@@ -7,6 +7,7 @@ enum BeadazzlePreferenceKeys {
     static let showsAssigneeInBeadList = "ShowsAssigneeInBeadList"
     static let showsDueDateInBeadList = "ShowsDueDateInBeadList"
     static let showsCommentsInBeadList = "ShowsCommentsInBeadList"
+    static let receivesBetaUpdates = "ReceivesBetaUpdates"
 
     static func hiddenTypes(projectURL: URL) -> String {
         "HiddenTypes.\(projectURL.standardizedFileURL.path)"

--- a/Sources/Beadazzle/Services/UpdaterController.swift
+++ b/Sources/Beadazzle/Services/UpdaterController.swift
@@ -1,0 +1,75 @@
+import Combine
+import Foundation
+import Sparkle
+
+/// Owns the Sparkle updater for the app.
+///
+/// Beadazzle ships outside the App Store and is not sandboxed, so the updater
+/// runs without XPC services (those are stripped from the embedded framework in
+/// `build_app_bundle.sh`). The "receive beta updates" preference is bridged into
+/// Sparkle's channel selection through `UpdaterChannelDelegate`, which Sparkle
+/// consults on every check — no restart or re-registration needed when it flips.
+@MainActor
+final class UpdaterController: ObservableObject {
+    let standardUpdaterController: SPUStandardUpdaterController
+    private let channelDelegate: UpdaterChannelDelegate
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+        let channelDelegate = UpdaterChannelDelegate(userDefaults: userDefaults)
+        self.channelDelegate = channelDelegate
+        // startingUpdater: true begins scheduled background checks immediately.
+        self.standardUpdaterController = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: channelDelegate,
+            userDriverDelegate: nil
+        )
+    }
+
+    var updater: SPUUpdater { standardUpdaterController.updater }
+
+    /// Bound by the Updates settings pane. Sparkle persists this itself.
+    var automaticallyChecksForUpdates: Bool {
+        get { updater.automaticallyChecksForUpdates }
+        set {
+            objectWillChange.send()
+            updater.automaticallyChecksForUpdates = newValue
+        }
+    }
+
+    /// Opts the app into Sparkle's `beta` appcast channel.
+    var receivesBetaUpdates: Bool {
+        get { userDefaults.bool(forKey: BeadazzlePreferenceKeys.receivesBetaUpdates) }
+        set {
+            objectWillChange.send()
+            userDefaults.set(newValue, forKey: BeadazzlePreferenceKeys.receivesBetaUpdates)
+        }
+    }
+}
+
+/// Returns the appcast channels the user is allowed to see. An empty set means
+/// stable-only; `beta` additionally surfaces items tagged `<sparkle:channel>beta`.
+private final class UpdaterChannelDelegate: NSObject, SPUUpdaterDelegate {
+    private let userDefaults: UserDefaults
+
+    init(userDefaults: UserDefaults) {
+        self.userDefaults = userDefaults
+    }
+
+    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+        userDefaults.bool(forKey: BeadazzlePreferenceKeys.receivesBetaUpdates) ? ["beta"] : []
+    }
+}
+
+/// Drives the enabled state of the "Check for Updates…" menu item so it dims
+/// while a check is already in flight.
+@MainActor
+final class CheckForUpdatesViewModel: ObservableObject {
+    @Published var canCheckForUpdates = false
+
+    init(updater: SPUUpdater) {
+        updater.publisher(for: \.canCheckForUpdates)
+            .assign(to: &$canCheckForUpdates)
+    }
+}

--- a/Sources/Beadazzle/Views/CheckForUpdatesView.swift
+++ b/Sources/Beadazzle/Views/CheckForUpdatesView.swift
@@ -1,0 +1,21 @@
+import Sparkle
+import SwiftUI
+
+/// The "Check for Updates…" item for the app menu. Disabled while Sparkle is
+/// already mid-check so the user can't stack requests.
+struct CheckForUpdatesView: View {
+    @ObservedObject private var viewModel: CheckForUpdatesViewModel
+    private let updater: SPUUpdater
+
+    init(updater: SPUUpdater) {
+        self.updater = updater
+        self.viewModel = CheckForUpdatesViewModel(updater: updater)
+    }
+
+    var body: some View {
+        Button("Check for Updates…") {
+            updater.checkForUpdates()
+        }
+        .disabled(!viewModel.canCheckForUpdates)
+    }
+}

--- a/Sources/Beadazzle/Views/SettingsView.swift
+++ b/Sources/Beadazzle/Views/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 private enum AppSettingsPane: String, CaseIterable, Identifiable, Hashable {
     case general
     case ui
+    case updates
 
     var id: Self { self }
 
@@ -12,6 +13,8 @@ private enum AppSettingsPane: String, CaseIterable, Identifiable, Hashable {
             "General"
         case .ui:
             "UI"
+        case .updates:
+            "Updates"
         }
     }
 
@@ -21,6 +24,8 @@ private enum AppSettingsPane: String, CaseIterable, Identifiable, Hashable {
             "gearshape"
         case .ui:
             "sidebar.leading"
+        case .updates:
+            "arrow.down.circle"
         }
     }
 }
@@ -64,6 +69,8 @@ private struct AppSettingsDetail: View {
             GeneralSettingsPane()
         case .ui:
             UISettingsPane()
+        case .updates:
+            UpdatesSettingsPane()
         }
     }
 }
@@ -120,6 +127,26 @@ private struct GeneralSettingsPane: View {
     private func chooseBDCLIPath() {
         guard let url = PanelService.chooseExecutable(title: "Choose bd CLI") else { return }
         store.bdCLIPath = url.path
+    }
+}
+
+private struct UpdatesSettingsPane: View {
+    @EnvironmentObject private var updater: UpdaterController
+
+    var body: some View {
+        Form {
+            Section("Software Update") {
+                Toggle("Automatically check for updates", isOn: $updater.automaticallyChecksForUpdates)
+                Toggle("Receive beta updates", isOn: $updater.receivesBetaUpdates)
+            }
+
+            Section {
+                Text("Beta updates deliver pre-release builds as soon as they ship. Turn this off to only receive stable releases once they are available.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .settingsGroupedForm()
     }
 }
 

--- a/docs/AUTO_UPDATES.md
+++ b/docs/AUTO_UPDATES.md
@@ -1,0 +1,89 @@
+# Auto-updates (Sparkle) & changelog
+
+Beadazzle ships automatic updates via [Sparkle 2](https://sparkle-project.org).
+On first launch Sparkle asks whether to enable automatic update checks (its
+standard opt-in). Once enabled, it checks an appcast feed in the background and
+presents a changelog with **Install** / **Skip**. A **Check for Updates…** item
+lives in the app menu, and the **Updates** settings pane exposes automatic-check
+and beta-channel toggles.
+
+- **Feed:** `https://mosnar.github.io/beadazzle/appcast.xml` (GitHub Pages)
+- **Downloads:** the notarized DMGs already attached to each GitHub Release
+- **Channels:** pre-release tags (`vX.Y.Z-beta.N`) are published to the `beta`
+  channel; final tags (`vX.Y.Z`) go to the default (stable) channel. Users only
+  see beta items if they enable "Receive beta updates".
+
+The release workflow (`.github/workflows/release.yml`) builds the app, notarizes
+it, publishes the GitHub Release, regenerates the appcast, and deploys it to
+Pages — all from a tag push. The pieces below are the **one-time setup** that
+must be done by a human before the first Sparkle-enabled release.
+
+## One-time setup
+
+### 1. Generate the EdDSA signing key
+
+Sparkle signs each update with an EdDSA (ed25519) key. The **public** key is
+baked into the app; the **private** key signs the appcast in CI.
+
+```bash
+# Download the Sparkle tools (match SPARKLE_TOOLS_VERSION in the workflow / Package.swift)
+curl -fsSL https://github.com/sparkle-project/Sparkle/releases/download/2.9.4/Sparkle-2.9.4.tar.xz | tar -xJ bin/
+./bin/generate_keys                     # creates the private key in your login Keychain, prints the PUBLIC key
+./bin/generate_keys -x private-key.txt  # exports the base64 PRIVATE key to a file
+```
+
+Keep `private-key.txt` out of git (delete it after step 3). The public key is
+not secret.
+
+### 2. Publish the public key
+
+Set it as a **repository variable** so the build can bake it into `Info.plist`:
+
+- GitHub → Settings → Secrets and variables → Actions → **Variables** tab
+- New variable: `SPARKLE_ED_PUBLIC_KEY` = the public key printed in step 1
+
+(Optional) for local release builds, paste the same value into
+`BEADAZZLE_SPARKLE_PUBLIC_KEY` in `script/release_common.sh`. Not needed for CI.
+
+### 3. Publish the private key
+
+Set it as a **secret** in the same environment as the Apple signing secrets:
+
+- GitHub → Settings → Environments → **public-beta-release** → Add secret
+- `SPARKLE_ED_PRIVATE_KEY` = the full contents of `private-key.txt`
+
+Then `rm private-key.txt`.
+
+### 4. Enable GitHub Pages
+
+- GitHub → Settings → **Pages** → Source = **GitHub Actions**
+
+The `deploy_appcast` job publishes `appcast.xml` here. After the first release,
+confirm the feed loads at `https://mosnar.github.io/beadazzle/appcast.xml`.
+
+## Cutting a release
+
+1. Move the finished items in `CHANGELOG.md` from `## [Unreleased]` into a new
+   `## [X.Y.Z-beta.N]` heading (with the date), and add fresh link references at
+   the bottom. Leave a new empty `## [Unreleased]` section.
+2. Commit, then tag and push: `git tag vX.Y.Z-beta.N && git push --tags`.
+
+The workflow then:
+- runs tests, builds + notarizes the signed DMG,
+- reads the matching `CHANGELOG.md` section for both the GitHub Release notes
+  and the in-app update dialog (**the release fails if that section is
+  missing** — this keeps notes honest),
+- regenerates and re-signs the appcast (preserving prior entries) and deploys it
+  to Pages.
+
+## Notes & gotchas
+
+- **The current `v0.1.0-beta.1` build predates Sparkle**, so already-installed
+  copies can't self-update to the first Sparkle release — that one is a manual
+  download. Every release after it updates automatically.
+- The app is **not sandboxed**, so the build strips Sparkle's `XPCServices` and
+  signs the framework inside-out (see `beadazzle_release_sign_sparkle`). Don't
+  reintroduce `codesign --deep` on the app bundle.
+- Release notes are embedded into the appcast from the rendered changelog HTML.
+  After the first release, open the appcast and confirm the `<description>`
+  renders the way you expect in the update dialog.

--- a/script/build_app_bundle.sh
+++ b/script/build_app_bundle.sh
@@ -114,15 +114,27 @@ cat >"$info_plist" <<PLIST
   <true/>
   <key>NSPrincipalClass</key>
   <string>NSApplication</string>
+  <key>SUFeedURL</key>
+  <string>$BEADAZZLE_SPARKLE_FEED_URL</string>
 </dict>
 </plist>
 PLIST
+
+if [[ -n "$BEADAZZLE_SPARKLE_PUBLIC_KEY" ]]; then
+  /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string $BEADAZZLE_SPARKLE_PUBLIC_KEY" "$info_plist" >/dev/null
+else
+  printf 'warning: BEADAZZLE_SPARKLE_PUBLIC_KEY is unset; built app cannot verify updates\n' >&2
+fi
+
+beadazzle_release_embed_sparkle "$app_contents"
 
 app_resources="$app_contents/Resources"
 if beadazzle_release_write_app_icon "$BEADAZZLE_APP_ICON_SOURCE" "$app_resources"; then
   /usr/libexec/PlistBuddy -c "Add :CFBundleIconFile string AppIcon" "$info_plist" >/dev/null
 fi
 
+/usr/bin/xattr -cr "$app_bundle"
+beadazzle_release_sign_sparkle "$codesign_identity" "$app_contents/Frameworks"
 beadazzle_release_sign_app_bundle "$codesign_identity" "$app_bundle"
 beadazzle_release_verify_app_bundle_signature "$app_bundle"
 

--- a/script/build_appcast.sh
+++ b/script/build_appcast.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/release_common.sh"
+
+usage() {
+  cat <<EOF
+usage: $0 --dmg-path <path> --release-tag <tag> --notes-html <path> \\
+          --generate-appcast <path> --output-dir <dir>
+
+Builds/updates the Sparkle appcast for a release and writes appcast.xml into
+--output-dir (ready to publish to GitHub Pages).
+
+Behavior:
+  - Seeds from the currently published appcast so prior entries are preserved.
+  - Signs the DMG with the EdDSA private key read from the SPARKLE_ED_PRIVATE_KEY
+    environment variable (base64, as printed by Sparkle's generate_keys).
+  - Points download URLs at the tag's GitHub release asset.
+  - Assigns pre-release tags (those containing a hyphen, e.g. v1.2.3-beta.1) to
+    the Sparkle "beta" channel; final releases go to the default channel.
+EOF
+}
+
+dmg_path=""
+release_tag=""
+notes_html=""
+generate_appcast=""
+output_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dmg-path)
+      dmg_path="${2:?missing value for --dmg-path}"
+      shift 2
+      ;;
+    --release-tag)
+      release_tag="${2:?missing value for --release-tag}"
+      shift 2
+      ;;
+    --notes-html)
+      notes_html="${2:?missing value for --notes-html}"
+      shift 2
+      ;;
+    --generate-appcast)
+      generate_appcast="${2:?missing value for --generate-appcast}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:?missing value for --output-dir}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      beadazzle_release_die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$dmg_path" ]] || { usage >&2; beadazzle_release_die "missing --dmg-path"; }
+[[ -n "$release_tag" ]] || { usage >&2; beadazzle_release_die "missing --release-tag"; }
+[[ -n "$generate_appcast" ]] || { usage >&2; beadazzle_release_die "missing --generate-appcast"; }
+[[ -n "$output_dir" ]] || { usage >&2; beadazzle_release_die "missing --output-dir"; }
+[[ -f "$dmg_path" ]] || beadazzle_release_die "DMG not found: $dmg_path"
+[[ -x "$generate_appcast" ]] || beadazzle_release_die "generate_appcast not executable: $generate_appcast"
+[[ -n "${SPARKLE_ED_PRIVATE_KEY:-}" ]] || beadazzle_release_die "missing SPARKLE_ED_PRIVATE_KEY environment value"
+
+beadazzle_release_require_command curl
+
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/beadazzle-appcast.XXXXXX")"
+key_file="$(mktemp "${TMPDIR:-/tmp}/beadazzle-ed-key.XXXXXX")"
+cleanup() {
+  rm -rf "$work_dir"
+  rm -f "$key_file"
+}
+trap cleanup EXIT
+
+# Stage the DMG being released.
+dmg_name="$(basename "$dmg_path")"
+cp "$dmg_path" "$work_dir/$dmg_name"
+
+# Release notes: generate_appcast embeds a sibling <archive-basename>.html file
+# as the item's description.
+if [[ -n "$notes_html" && -f "$notes_html" ]]; then
+  cp "$notes_html" "$work_dir/${dmg_name%.dmg}.html"
+fi
+
+# Preserve previously published entries by seeding the existing appcast.
+if curl -fsSL "$BEADAZZLE_SPARKLE_FEED_URL" -o "$work_dir/appcast.xml"; then
+  printf 'Seeded existing appcast from %s\n' "$BEADAZZLE_SPARKLE_FEED_URL" >&2
+else
+  printf 'No existing appcast found; starting a fresh feed\n' >&2
+  rm -f "$work_dir/appcast.xml"
+fi
+
+# Write the private key to a file for --ed-key-file (avoids leaking via argv).
+printf '%s' "$SPARKLE_ED_PRIVATE_KEY" > "$key_file"
+
+download_prefix="https://github.com/Mosnar/beadazzle/releases/download/$release_tag/"
+
+generate_args=(
+  "$work_dir"
+  --ed-key-file "$key_file"
+  --download-url-prefix "$download_prefix"
+)
+
+# A semver pre-release identifier always contains a hyphen (e.g. -beta.1).
+if [[ "$release_tag" == *-* ]]; then
+  generate_args+=(--channel beta)
+fi
+
+"$generate_appcast" "${generate_args[@]}" >&2
+
+[[ -f "$work_dir/appcast.xml" ]] || beadazzle_release_die "generate_appcast did not produce appcast.xml"
+
+mkdir -p "$output_dir"
+cp "$work_dir/appcast.xml" "$output_dir/appcast.xml"
+printf '%s\n' "$output_dir/appcast.xml"

--- a/script/extract_changelog.sh
+++ b/script/extract_changelog.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/release_common.sh"
+
+usage() {
+  cat <<EOF
+usage: $0 --version <tag> [--changelog <path>]
+
+Prints the CHANGELOG.md section body for the given version to stdout.
+The version may be given with or without a leading 'v' (e.g. v0.1.0-beta.1).
+Exits non-zero if no matching section exists, so a release can fail loudly
+when notes are missing.
+EOF
+}
+
+version=""
+changelog="$BEADAZZLE_ROOT_DIR/CHANGELOG.md"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      version="${2:?missing value for --version}"
+      shift 2
+      ;;
+    --changelog)
+      changelog="${2:?missing value for --changelog}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      beadazzle_release_die "unknown argument: $1"
+      ;;
+  esac
+done
+
+[[ -n "$version" ]] || { usage >&2; beadazzle_release_die "missing --version"; }
+[[ -f "$changelog" ]] || beadazzle_release_die "changelog not found: $changelog"
+
+# Match the heading regardless of a leading 'v'.
+version="${version#v}"
+
+# Grab lines between "## [<version>]" and the next "## [" heading, dropping
+# link-reference definitions ([x]: url) and any leading blank lines.
+section="$(awk -v target="$version" '
+  /^## \[/ {
+    header = $0
+    sub(/^## \[/, "", header)
+    sub(/\].*/, "", header)
+    grab = (header == target) ? 1 : 0
+    next
+  }
+  grab { print }
+' "$changelog" | grep -v '^\[[^]]*\]: ' | awk 'NF { seen = 1 } seen { print }')"
+
+if [[ -z "${section//[[:space:]]/}" ]]; then
+  beadazzle_release_die "no changelog section found for version: $version"
+fi
+
+printf '%s\n' "$section"

--- a/script/release_common.sh
+++ b/script/release_common.sh
@@ -18,6 +18,14 @@ readonly BEADAZZLE_ROOT_DIR
 readonly BEADAZZLE_DIST_DIR="$BEADAZZLE_ROOT_DIR/dist"
 readonly BEADAZZLE_APP_ICON_SOURCE="$BEADAZZLE_ROOT_DIR/Resources/AppIcon.png"
 
+# Sparkle auto-update configuration.
+# The appcast is published to GitHub Pages by the release workflow.
+readonly BEADAZZLE_SPARKLE_FEED_URL="https://mosnar.github.io/beadazzle/appcast.xml"
+# EdDSA public key baked into Info.plist so the app can verify update signatures.
+# Not secret. Generated once with Sparkle's `generate_keys`; paste the public key
+# here (or override via the BEADAZZLE_SPARKLE_PUBLIC_KEY env var in CI).
+BEADAZZLE_SPARKLE_PUBLIC_KEY="${BEADAZZLE_SPARKLE_PUBLIC_KEY:-}"
+
 beadazzle_release_die() {
   printf 'error: %s\n' "$*" >&2
   exit 1
@@ -113,7 +121,10 @@ beadazzle_release_write_app_icon() {
 beadazzle_release_sign_app_bundle() {
   local identity="$1"
   local app_bundle="$2"
-  local -a command=(/usr/bin/codesign --force --deep --sign "$identity")
+  # No --deep: nested code (Sparkle.framework) is signed inside-out beforehand
+  # via beadazzle_release_sign_sparkle. This seals the outer bundle and its main
+  # executable while leaving the already-valid nested signatures intact.
+  local -a command=(/usr/bin/codesign --force --sign "$identity")
 
   if ! beadazzle_release_is_ad_hoc_identity "$identity"; then
     command+=(--options runtime --timestamp)
@@ -129,6 +140,73 @@ beadazzle_release_sign_file() {
 
   if ! beadazzle_release_is_ad_hoc_identity "$identity"; then
     command+=(--timestamp)
+  fi
+
+  "${command[@]}" "$target_path"
+}
+
+# Locate the macOS Sparkle.framework SwiftPM extracts from its XCFramework.
+# Prefers the build artifacts dir over the index-build copy.
+beadazzle_release_locate_sparkle_framework() {
+  local framework
+  framework="$(/usr/bin/find "$BEADAZZLE_ROOT_DIR/.build" -type d -name 'Sparkle.framework' -path '*.xcframework/macos*' 2>/dev/null \
+    | grep -v '/index-build/' \
+    | head -n1)"
+  [[ -n "$framework" ]] || beadazzle_release_die "could not locate Sparkle.framework under .build; run 'swift build' first"
+  printf '%s\n' "$framework"
+}
+
+# Copy Sparkle.framework into the bundle, drop the XPC services (only needed by
+# sandboxed apps; Beadazzle is not sandboxed), and add an rpath so the main
+# executable resolves @rpath/Sparkle.framework at launch.
+beadazzle_release_embed_sparkle() {
+  local app_contents="$1"
+  local frameworks_dir="$app_contents/Frameworks"
+  local main_binary="$app_contents/MacOS/$BEADAZZLE_APP_NAME"
+  local source_framework
+  source_framework="$(beadazzle_release_locate_sparkle_framework)"
+
+  local framework="$frameworks_dir/Sparkle.framework"
+  mkdir -p "$frameworks_dir"
+  rm -rf "$framework"
+  /usr/bin/ditto "$source_framework" "$framework"
+
+  # Drop the XPC services (unused by non-sandboxed apps). Remove both the real
+  # directory and the top-level symlink that points at it, otherwise the dangling
+  # symlink breaks later xattr/codesign passes over the framework.
+  rm -rf "$framework/Versions/Current/XPCServices"
+  rm -f "$framework/XPCServices"
+
+  # Adding an rpath invalidates the ad-hoc signature SwiftPM applies to the main
+  # binary, but it is re-signed after embedding. Ignore "would duplicate" on reruns.
+  /usr/bin/install_name_tool -add_rpath "@executable_path/../Frameworks" "$main_binary" 2>/dev/null || true
+}
+
+# Sign Sparkle's nested code inside-out (helpers before the framework bundle).
+# Deliberately avoids `codesign --deep`, which Apple deprecates and which does
+# not correctly apply hardened-runtime options to nested bundles.
+beadazzle_release_sign_sparkle() {
+  local identity="$1"
+  local frameworks_dir="$2"
+  local framework="$frameworks_dir/Sparkle.framework"
+  local versioned="$framework/Versions/Current"
+
+  [[ -d "$framework" ]] || beadazzle_release_die "Sparkle.framework not embedded before signing: $framework"
+
+  [[ -e "$versioned/Autoupdate" ]] && beadazzle_release_sign_hardened "$identity" "$versioned/Autoupdate"
+  [[ -d "$versioned/Updater.app" ]] && beadazzle_release_sign_hardened "$identity" "$versioned/Updater.app"
+  beadazzle_release_sign_hardened "$identity" "$framework"
+}
+
+# Sign a single target with the hardened runtime + secure timestamp for real
+# Developer ID identities (skipped for the ad-hoc "-" identity used locally).
+beadazzle_release_sign_hardened() {
+  local identity="$1"
+  local target_path="$2"
+  local -a command=(/usr/bin/codesign --force --sign "$identity")
+
+  if ! beadazzle_release_is_ad_hoc_identity "$identity"; then
+    command+=(--options runtime --timestamp)
   fi
 
   "${command[@]}" "$target_path"


### PR DESCRIPTION
Adds automatic updates via [Sparkle 2](https://sparkle-project.org): background checks, an Install/Skip changelog dialog, a **Check for Updates…** menu item, and an **Updates** settings pane with automatic-check and beta-channel toggles. Release notes are driven by a `CHANGELOG.md`, and the release workflow regenerates and deploys the appcast to GitHub Pages.

## What's included
- **In-app updater** — `UpdaterController` owns Sparkle and bridges a "receive beta updates" preference into Sparkle's channel selection (stable-only vs. beta). First launch uses Sparkle's standard opt-in consent prompt.
- **Bundle/signing** — embeds `Sparkle.framework`, strips the unused `XPCServices` (non-sandboxed app) including its dangling top-level symlink, adds the framework rpath, and signs nested code inside-out with hardened runtime + timestamp (no `codesign --deep`).
- **Changelog** — Keep a Changelog `CHANGELOG.md` + `extract_changelog.sh`; the convention is documented in CLAUDE.md/AGENTS.md. The tag's section feeds both the GitHub release notes and the in-app update dialog, and a missing section fails the release early (in `validate`, before build/notarize).
- **Release automation** — `generate_appcast` EdDSA-signs the appcast (preserving prior entries, pre-release tags → `beta` channel) and deploys it to GitHub Pages. Sparkle pinned `exact: 2.9.4` across the dep and the tool.

## Verified locally
- `swift build` + 156 tests pass.
- Release-config bundle embeds the framework, signs inside-out, passes `codesign --verify --deep --strict`, and launches.
- An independent code review found no critical/high issues; its follow-ups (early changelog gate, exact version pin, first-run consent) are applied.

## Before this can ship (one-time, see `docs/AUTO_UPDATES.md`)
- [ ] Generate the EdDSA keypair
- [ ] Set repo variable `SPARKLE_ED_PUBLIC_KEY` and environment secret `SPARKLE_ED_PRIVATE_KEY`
- [ ] Enable GitHub Pages (source: GitHub Actions)
- [ ] Rename `## [Unreleased]` → the release version before tagging
- [ ] Confirm the first release's notarization is `Accepted` (only a real `notarytool` run proves the embedded framework notarizes)

> Note: the current `v0.1.0-beta.1` build predates Sparkle, so the first Sparkle release is a manual download; updates after it are automatic.

https://claude.ai/code/session_016hJvS7QEBJFa9tNmgDDe5B